### PR TITLE
Added 'onClose' method to know when the picker is closed

### DIFF
--- a/lib/src/date_picker.dart
+++ b/lib/src/date_picker.dart
@@ -47,6 +47,7 @@ class DatePicker {
     DateTimePickerMode pickerMode: DateTimePickerMode.date,
     DateTimePickerTheme pickerTheme: DateTimePickerTheme.Default,
     DateVoidCallback onCancel,
+    DateVoidCallback onClose,
     DateValueCallback onChange,
     DateValueCallback onConfirm,
   }) {
@@ -83,7 +84,7 @@ class DatePicker {
         barrierLabel:
             MaterialLocalizations.of(context).modalBarrierDismissLabel,
       ),
-    );
+    ).whenComplete(onClose);
   }
 }
 


### PR DESCRIPTION
Added 'onClose' method to know when the picker is closed. 
It will let you know when the 'DatePicker' would also be closed by an external gesture like the click outside of it.

It is required for use in combination with this plugin: https://pub.dev/packages/datetime_picker_formfield